### PR TITLE
Implement bowling kata in kotlin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# Bowling kata
+
+https://codingdojo.org/kata/Bowling/
+
+## Problem Description
+
+Create a program, which, given a valid sequence of rolls for one line of American Ten-Pin Bowling, produces the total
+score for the game.
+
+Here are some things that the program will not do:
+
+- We will not check for valid rolls.
+- We will not check for correct number of rolls and frames.
+- We will not provide scores for intermediate frames.
+
+Depending on the application, this might or might not be a valid way to define a complete story, but we do it here for
+purposes of keeping the kata light. I think you’ll see that improvements like those above would go in readily if they
+were needed for real.
+
+We can briefly summarize the scoring for this form of bowling:
+
+- Each game, or “line” of bowling, includes ten turns, or “frames” for the bowler.
+- In each frame, the bowler gets up to two tries to knock down all the pins.
+- If in two tries, he fails to knock them all down, his score for that frame is the total number of pins knocked down in
+  his two tries.
+- If in two tries he knocks them all down, this is called a “spare” and his score for the frame is ten plus the number
+  of pins knocked down on his next throw (in his next turn).
+- If on his first try in the frame he knocks down all the pins, this is called a “strike”. His turn is over, and his
+  score for the frame is ten plus the simple total of the pins knocked down in his next two rolls.
+- If he gets a spare or strike in the last (tenth) frame, the bowler gets to throw one or two more bonus balls,
+  respectively. These bonus throws are taken as part of the same turn. If the bonus throws knock down all the pins, the
+  process does not repeat: the bonus throws are only used to calculate the score of the final frame.
+- The game score is the total of all frame scores.
+
+## Suggested Test Cases
+
+(When scoring “X” indicates a strike, “/” indicates a spare, “-” indicates a miss)
+
+X X X X X X X X X X X X (12 rolls: 12 strikes) = 10 frames * 30 points = 300
+
+9- 9- 9- 9- 9- 9- 9- 9- 9- 9- (20 rolls: 10 pairs of 9 and miss) = 10 frames * 9 points = 90
+
+5/ 5/ 5/ 5/ 5/ 5/ 5/ 5/ 5/ 5/5 (21 rolls: 10 pairs of 5 and spare, with a final 5) = 10 frames * 15 points = 150

--- a/src/test/kotlin/lmirabal/bowling/BowlingTest.kt
+++ b/src/test/kotlin/lmirabal/bowling/BowlingTest.kt
@@ -59,13 +59,38 @@ class BowlingTest {
 
         assertEquals(240, total)
     }
+
+    @Test
+    fun `perfect game`() {
+        val total: Int = bowlingScore("X X X X X X X X X XXX")
+
+        assertEquals(300, total)
+    }
+
+    @Test
+    fun `perfect game but 1 pin on last throw`() {
+        val total: Int = bowlingScore("X X X X X X X X X XX1")
+
+        assertEquals(291, total)
+    }
+
+    @Test
+    fun `spares on the third throw in the last frame`() {
+        val total: Int = bowlingScore("X X X X X X X X X X1/")
+
+        assertEquals(281, total)
+    }
 }
 
 private fun bowlingScore(input: String): Int {
     return input.split(" ")
         .map { frame ->
             val throw1 = frame.substring(0, 1).parseNonSpareThrow()
-            val nextThrows = frame.drop(1).map { it.toString().parseSpareableThrow(throw1) }
+            val nextThrows = frame
+                .map { it.toString() }
+                .zipWithNext { previous, current ->
+                    current.parseSpareableThrow(previous)
+                }
             Frame.from(listOf(throw1) + nextThrows)
         }
         .windowed(size = 3, step = 1, partialWindows = true) { window ->
@@ -81,8 +106,8 @@ private fun String.parseNonSpareThrow() = when (this) {
     else -> toInt()
 }
 
-private fun String.parseSpareableThrow(throw1: Int) = when (this) {
-    "/" -> 10 - throw1
+private fun String.parseSpareableThrow(previousThrow: String) = when (this) {
+    "/" -> 10 - previousThrow.parseNonSpareThrow()
     else -> parseNonSpareThrow()
 }
 

--- a/src/test/kotlin/lmirabal/bowling/BowlingTest.kt
+++ b/src/test/kotlin/lmirabal/bowling/BowlingTest.kt
@@ -24,6 +24,13 @@ class BowlingTest {
 
         assertEquals(20, total)
     }
+
+    @Test
+    fun `knocks down an extra pin with each throw`() {
+        val total: Int = bowlingScore("-- 1- 2- 3- 4- 5- 6- 7- 8- 9-")
+
+        assertEquals(45, total)
+    }
 }
 
 private fun bowlingScore(input: String): Int {
@@ -36,4 +43,4 @@ private fun bowlingScore(input: String): Int {
     return frames.sum()
 }
 
-private fun String.parseThrow() = if (this == "-") 0 else 1
+private fun String.parseThrow() = this.toIntOrNull() ?: 0

--- a/src/test/kotlin/lmirabal/bowling/BowlingTest.kt
+++ b/src/test/kotlin/lmirabal/bowling/BowlingTest.kt
@@ -6,57 +6,72 @@ import kotlin.test.assertEquals
 class BowlingTest {
     @Test
     fun `all misses`() {
-        val total: Int = bowlingScore("-- -- -- -- -- -- -- -- -- --")
+        val total = bowlingScore("-- -- -- -- -- -- -- -- -- --")
 
         assertEquals(0, total)
     }
 
     @Test
     fun `knocks down 1 pin in each frame`() {
-        val total: Int = bowlingScore("1- 1- 1- 1- 1- 1- 1- 1- 1- 1-")
+        val total = bowlingScore("1- 1- 1- 1- 1- 1- 1- 1- 1- 1-")
 
         assertEquals(10, total)
     }
 
     @Test
     fun `knocks down 1 pin in each throw`() {
-        val total: Int = bowlingScore("11 11 11 11 11 11 11 11 11 11")
+        val total = bowlingScore("11 11 11 11 11 11 11 11 11 11")
 
         assertEquals(20, total)
     }
 
     @Test
     fun `knocks down an extra pin with each throw`() {
-        val total: Int = bowlingScore("-- 1- 2- 3- 4- 5- 6- 7- 8- 9-")
+        val total = bowlingScore("-- 1- 2- 3- 4- 5- 6- 7- 8- 9-")
 
         assertEquals(45, total)
     }
 
     @Test
     fun `spares in first frame and knocks down 5 in the others`() {
-        val total: Int = bowlingScore("-/ 5- 5- 5- 5- 5- 5- 5- 5- 5-")
+        val total = bowlingScore("-/ 5- 5- 5- 5- 5- 5- 5- 5- 5-")
 
         assertEquals(60, total)
+    }
+
+    @Test
+    fun `knocks down 5 pins and spares except last frame`() {
+        val total = bowlingScore("5/ 5/ 5/ 5/ 5/ 5/ 5/ 5/ 5/ --")
+
+        assertEquals(130, total)
     }
 }
 
 private fun bowlingScore(input: String): Int {
-    val throws = input.split(" ")
-        .flatMap { frame ->
-            val throw1 = frame.substring(0, 1).parseThrow()
-            val throw2 = frame.substring(1, 2).parseThrow()
-            listOf(throw1, throw2)
+    val frames = input.split(" ")
+        .map { frame ->
+            val throw1 = frame.substring(0, 1).parse9PinThrow()
+            val throw2 = frame.substring(1, 2).parseSecondThrow(throw1)
+            Frame(throw1, throw2)
         }
     var total = 0
-    for (i in throws.indices) {
-        val current = throws[i]
-        total += if (current != 10) current else current + throws[i + 1]
+    for (i in frames.indices) {
+        val current = frames[i].score()
+        total += if (current < 10) current else current + frames[i + 1].throw1
     }
     return total
 }
 
-private fun String.parseThrow() = when (this) {
-    "/" -> 10
+private fun String.parse9PinThrow() = when (this) {
     "-" -> 0
     else -> toInt()
+}
+
+private fun String.parseSecondThrow(throw1: Int) = when (this) {
+    "/" -> 10 - throw1
+    else -> parse9PinThrow()
+}
+
+data class Frame(val throw1: Int, val throw2: Int) {
+    fun score() = throw1 + throw2
 }

--- a/src/test/kotlin/lmirabal/bowling/BowlingTest.kt
+++ b/src/test/kotlin/lmirabal/bowling/BowlingTest.kt
@@ -10,8 +10,17 @@ class BowlingTest {
 
         assertEquals(0, total)
     }
+
+    @Test
+    fun `knocks down 1 pin in each frame`() {
+        val total: Int = bowlingScore("1- 1- 1- 1- 1- 1- 1- 1- 1- 1-")
+
+        assertEquals(10, total)
+    }
 }
 
 private fun bowlingScore(input: String): Int {
-    return 0
+    val frames = input.split(" ")
+        .map { frame -> if (frame.startsWith("-")) 0 else 1 }
+    return frames.sum()
 }

--- a/src/test/kotlin/lmirabal/bowling/BowlingTest.kt
+++ b/src/test/kotlin/lmirabal/bowling/BowlingTest.kt
@@ -1,0 +1,17 @@
+package lmirabal.bowling
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class BowlingTest {
+    @Test
+    fun `all misses`() {
+        val total: Int = bowlingScore("-- -- -- -- -- -- -- -- -- --")
+
+        assertEquals(0, total)
+    }
+}
+
+private fun bowlingScore(input: String): Int {
+    return 0
+}

--- a/src/test/kotlin/lmirabal/bowling/BowlingTest.kt
+++ b/src/test/kotlin/lmirabal/bowling/BowlingTest.kt
@@ -48,18 +48,19 @@ class BowlingTest {
 }
 
 private fun bowlingScore(input: String): Int {
-    val frames = input.split(" ")
+    return input.split(" ")
         .map { frame ->
             val throw1 = frame.substring(0, 1).parse9PinThrow()
             val throw2 = frame.substring(1, 2).parseSecondThrow(throw1)
             Frame(throw1, throw2)
         }
-    var total = 0
-    for (i in frames.indices) {
-        val current = frames[i].score()
-        total += if (current < 10) current else current + frames[i + 1].throw1
-    }
-    return total
+        .windowed(size = 2, step = 1, partialWindows = true) { window ->
+            val currentFrameScore = window.first().score()
+            val nextFrame = window.last()
+            if (currentFrameScore < 10) currentFrameScore
+            else currentFrameScore + nextFrame.throw1
+        }
+        .sum()
 }
 
 private fun String.parse9PinThrow() = when (this) {

--- a/src/test/kotlin/lmirabal/bowling/BowlingTest.kt
+++ b/src/test/kotlin/lmirabal/bowling/BowlingTest.kt
@@ -17,10 +17,21 @@ class BowlingTest {
 
         assertEquals(10, total)
     }
+
+    @Test
+    fun `knocks down 1 pin in each throw`() {
+        val total: Int = bowlingScore("11 11 11 11 11 11 11 11 11 11")
+
+        assertEquals(20, total)
+    }
 }
 
 private fun bowlingScore(input: String): Int {
     val frames = input.split(" ")
-        .map { frame -> if (frame.startsWith("-")) 0 else 1 }
+        .map { frame ->
+            val throw1 = if (frame.substring(0, 1) == "-") 0 else 1
+            val throw2 = if (frame.substring(1, 2) == "-") 0 else 1
+            throw1 + throw2
+        }
     return frames.sum()
 }

--- a/src/test/kotlin/lmirabal/bowling/BowlingTest.kt
+++ b/src/test/kotlin/lmirabal/bowling/BowlingTest.kt
@@ -31,16 +31,32 @@ class BowlingTest {
 
         assertEquals(45, total)
     }
+
+    @Test
+    fun `spares in first frame and knocks down 5 in the others`() {
+        val total: Int = bowlingScore("-/ 5- 5- 5- 5- 5- 5- 5- 5- 5-")
+
+        assertEquals(60, total)
+    }
 }
 
 private fun bowlingScore(input: String): Int {
-    val frames = input.split(" ")
-        .map { frame ->
+    val throws = input.split(" ")
+        .flatMap { frame ->
             val throw1 = frame.substring(0, 1).parseThrow()
             val throw2 = frame.substring(1, 2).parseThrow()
-            throw1 + throw2
+            listOf(throw1, throw2)
         }
-    return frames.sum()
+    var total = 0
+    for (i in throws.indices) {
+        val current = throws[i]
+        total += if (current != 10) current else current + throws[i + 1]
+    }
+    return total
 }
 
-private fun String.parseThrow() = this.toIntOrNull() ?: 0
+private fun String.parseThrow() = when (this) {
+    "/" -> 10
+    "-" -> 0
+    else -> toInt()
+}

--- a/src/test/kotlin/lmirabal/bowling/BowlingTest.kt
+++ b/src/test/kotlin/lmirabal/bowling/BowlingTest.kt
@@ -29,9 +29,11 @@ class BowlingTest {
 private fun bowlingScore(input: String): Int {
     val frames = input.split(" ")
         .map { frame ->
-            val throw1 = if (frame.substring(0, 1) == "-") 0 else 1
-            val throw2 = if (frame.substring(1, 2) == "-") 0 else 1
+            val throw1 = frame.substring(0, 1).parseThrow()
+            val throw2 = frame.substring(1, 2).parseThrow()
             throw1 + throw2
         }
     return frames.sum()
 }
+
+private fun String.parseThrow() = if (this == "-") 0 else 1


### PR DESCRIPTION
### Bowling kata problem description

### Start scoring for all misses

### 1 pin per frame

Keep to the simplest implementation that makes the test pass.

Only parse first throw and sum. If it's not a number, assume 0.

### 1 pin per throw

Parse both throws and sum them.

### Tidy up parsing by extracting function

### Remove hard-coded throw calculation

New test case that defers from 0/1 to drive throw parsing.

### Look ahead to work out a spare

Use for-loop to easily look ahead. Assume 10 as spare and sum next throw
if seen.

### Work out pin count of spare throw so the frame sum is 10

The new test case knocks down pins in the first throw, so 10 can't be
assumed for the spare throw but for the whole frame.

This makes the parsing trickier as when a spare is seen, the value of
the first throw is needed. However, as the first throw can't be a spare,
split the parsing into 2, so the one for the second throw can have the
first throw as param.

### Make calculation more functional to avoid mutable variables

Use windowing to get the current frame and the next.

### Support spare on the final frame

Move score calculation into the frame type having a special strategy for
spare frames.

The final frame gets supported automatically when abstract the throws as
a list because it needs to count the knocked down pins as a normal
non-spare frame.

### Work out strike looking ahead the next 2 throws

They can come from the next 2 frames if they were strikes, so increase
the window size but flatten them out into throws so that the strike
can be calculated without knowledge of which frames the throws come from
as that detail is not relevant.

Naming the functions that parse throws is a bit tricky, so decided on
making clear which one can end up in a spare.

### Add support for spare on the third shot in the final frame

Other combinations of throws in the final frame where nicely supported
by the existing implementation.

However, spare in other than the second throw had issues, as the first
throw was always used for the calculation rather than the previous one.